### PR TITLE
Update ANOVA.jl, fixing line 7

### DIFF
--- a/src/ANOVA.jl
+++ b/src/ANOVA.jl
@@ -4,7 +4,7 @@ export MM_ANOVA
 function two_way_ANOVA(Y::Array{T, 3}) where T <: Real
   (i, j, k) = size(Y)
   S = sum(Y, dims = 3)
-  (alpha, beta) = (sum(S, dims = 2), beta = sum(S, dims = 1))
+  (alpha, beta) = (alpha = sum(S, dims = 2), beta = sum(S, dims = 1))
   mu = sum(alpha) / (i * j * k)
   alpha = alpha / (j * k) .- mu
   beta = beta / (i * k) .- mu

--- a/test/mcda_test.jl
+++ b/test/mcda_test.jl
@@ -37,7 +37,7 @@ function analyze_iris_data(epsilon::T, missing_rate::T,
   end
   for r = 1:6 # run MCDA
     imputedclass = mcda(M, deletedclass, classes, r, epsilon);
-    errors = count(class - imputedclass != 0);
+    errors = count(class - imputedclass .!= 0);
     println("rank = ", r," classification_errors = ", errors)
   end
   return nothing


### PR DESCRIPTION
I think this simple change may suffice to fix the precompilation issue I reported in this GitHub Issue:

https://github.com/KennethLange/AlgorithmsFromTheBook.jl/issues/1

Change line 7 of ANOVA.jl from

```
(alpha, beta) = (sum(S, dims = 2), beta = sum(S, dims = 1))
```

to

```
(alpha, beta) = (alpha = sum(S, dims = 2), beta = sum(S, dims = 1))
```

```
julia> function two_way_ANOVA(Y::Array{T, 3}) where T <: Real
         (i, j, k) = size(Y)
         S = sum(Y, dims = 3)
         (alpha, beta) = (sum(S, dims = 2), beta = sum(S, dims = 1))
         mu = sum(alpha) / (i * j * k)
         alpha = alpha / (j * k) .- mu
         beta = beta / (i * k) .- mu
         return (mu, alpha, beta)
       end
ERROR: syntax: invalid named tuple element "sum(S, dims = 2)" around REPL[31]:4
Stacktrace:
 [1] top-level scope
   @ REPL[31]:1

julia> function two_way_ANOVA(Y::Array{T, 3}) where T <: Real
         (i, j, k) = size(Y)
         S = sum(Y, dims = 3)
         (alpha, beta) = (alpha=sum(S, dims = 2), beta = sum(S, dims = 1))
         mu = sum(alpha) / (i * j * k)
         alpha = alpha / (j * k) .- mu
         beta = beta / (i * k) .- mu
         return (mu, alpha, beta)
       end
two_way_ANOVA (generic function with 1 method)
```